### PR TITLE
reorganize the api server

### DIFF
--- a/docker/aarch64.Dockerfile
+++ b/docker/aarch64.Dockerfile
@@ -1,16 +1,19 @@
 #FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:edge-centos
 #FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:0.2.5
 #FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu@sha256:b4eff900bf2007cbcb54335a5826dedde6082f484bc8be7499d5ed071608ecf3
-FROM nvcr.io/nvidia/l4t-base:r35.2.1
+FROM nvcr.io/nvidia/l4t-base:r32.2.1
 
 RUN apt-get update && apt-get install --assume-yes \
     cmake \
     curl \
+    gdb \
     pkg-config \
     && \
     apt-get clean
 
 RUN dpkg --add-architecture arm64
+
+ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install --assume-yes \
     nasm \

--- a/scripts/cross_deploy.sh
+++ b/scripts/cross_deploy.sh
@@ -47,7 +47,7 @@ fi
 
 # Build the release binary
 print_status "Building release binary for aarch64..."
-cross build --target $DEPLOY_ARCH --release --bin $BINARY_NAME || print_error "Build failed"
+cross build --target $DEPLOY_ARCH --release -v --bin $BINARY_NAME || print_error "Build failed"
 rsync -a target/$DEPLOY_ARCH/release/$BINARY_NAME $LOCAL_FOLDER
 
 # Check if binary exists

--- a/src/api/handles.rs
+++ b/src/api/handles.rs
@@ -1,0 +1,150 @@
+use ::cu29::read_configuration;
+use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
+
+use axum::{
+    extract::State,
+    response::{IntoResponse, Json},
+};
+use reqwest::StatusCode;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+use crate::{
+    cu29,
+    pipeline::{self, PipelineHandle, PipelineInfo, PipelineStatus, PipelineStore},
+};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct PipelineStartRequest {
+    // the id of the pipeline to start
+    pub pipeline_id: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct PipelineStopRequest {
+    // the id of the pipeline to stop
+    pub pipeline_id: String,
+}
+
+/// Start a pipeline given its id
+pub async fn start_pipeline(
+    State(store): State<PipelineStore>,
+    Json(request): Json<PipelineStartRequest>,
+) -> impl IntoResponse {
+    // TODO: create a pipeline factory so that from the REST API we can register
+    //       a new pipeline and start it
+    // NOTE: for now we only support one pipeline ["bubbaloop"]
+    const SUPPORTED_PIPELINES: [&str; 2] = ["bubbaloop", "recording"];
+    if !SUPPORTED_PIPELINES.contains(&request.pipeline_id.as_str()) {
+        log::error!(
+            "Pipeline {} not supported. Try 'bubbaloop' or 'recording' instead",
+            request.pipeline_id
+        );
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({
+                "error": "Pipeline not supported. Try 'bubbaloop' instead",
+            })),
+        );
+    }
+
+    // check if the pipeline id is already in the store
+    let pipeline_id = request.pipeline_id;
+    let mut pipeline_store = store.0.lock().expect("Failed to lock pipeline store");
+
+    if pipeline_store.contains_key(&pipeline_id) {
+        log::error!("Pipeline {} already exists", pipeline_id);
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({
+                "error": "Pipeline already exists",
+            })),
+        );
+    }
+
+    // the stop signal to kill the pipeline thread
+    let stop_signal = Arc::new(AtomicBool::new(false));
+
+    let handle = match pipeline_id.as_str() {
+        "bubbaloop" => pipeline::dummy_bubbaloop_thread(&pipeline_id, stop_signal.clone()),
+        "recording" => cu29::app::spawn_cu29_thread(&pipeline_id, stop_signal.clone()),
+        _ => {
+            log::error!("Pipeline {} not supported", pipeline_id);
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({ "error": "Pipeline not supported" })),
+            );
+        }
+    };
+
+    // add the pipeline handle to the store
+    pipeline_store.insert(
+        pipeline_id.clone(),
+        PipelineHandle {
+            id: pipeline_id.clone(),
+            handle,
+            status: PipelineStatus::Running,
+            stop_signal,
+        },
+    );
+
+    (
+        StatusCode::OK,
+        Json(json!({
+            "message": format!("Pipeline {} started", pipeline_id),
+        })),
+    )
+}
+
+// Stop a pipeline given its id
+pub async fn stop_pipeline(
+    State(store): State<PipelineStore>,
+    Json(request): Json<PipelineStopRequest>,
+) -> impl IntoResponse {
+    log::debug!("Request to stop pipeline: {}", request.pipeline_id);
+    if !store.unregister_pipeline(&request.pipeline_id) {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({
+                "error": "Pipeline not found",
+            })),
+        );
+    }
+
+    (
+        StatusCode::OK,
+        Json(json!({ "message": format!("Pipeline {} stopped", request.pipeline_id) })),
+    )
+}
+
+// List all pipelines and return their status
+pub async fn list_pipelines(State(store): State<PipelineStore>) -> impl IntoResponse {
+    let store = store.0.lock().expect("Failed to lock pipeline store");
+    let pipelines = store
+        .values()
+        .map(|pipeline| PipelineInfo {
+            id: pipeline.id.clone(),
+            status: pipeline.status.clone(),
+        })
+        .collect::<Vec<_>>();
+    Json(pipelines)
+}
+
+/// Get the current configuration pipeline
+pub async fn get_config(State(_store): State<PipelineStore>) -> impl IntoResponse {
+    let copper_config = match read_configuration("bubbaloop.ron") {
+        Ok(config) => config,
+        Err(e) => {
+            log::error!("Failed to read configuration: {}", e);
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "error": "Failed to read configuration" })),
+            );
+        }
+    };
+
+    let all_nodes = copper_config.get_all_nodes();
+
+    (StatusCode::OK, Json(json!(all_nodes)))
+}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,0 +1,4 @@
+mod server;
+pub use server::ApiServer;
+
+pub mod handles;

--- a/src/bin/bubbaloop.rs
+++ b/src/bin/bubbaloop.rs
@@ -164,7 +164,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             PipelineMode::Start(pipeline_start_command) => {
                 let response = client
                     .post(format!("http://{}/api/v0/pipeline/start", addr))
-                    .json(&bubbaloop::pipeline::PipelineStartRequest {
+                    .json(&bubbaloop::api::handles::PipelineStartRequest {
                         pipeline_id: pipeline_start_command.id,
                     })
                     .send()
@@ -176,7 +176,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             PipelineMode::Stop(pipeline_stop_command) => {
                 let response = client
                     .post(format!("http://{}/api/v0/pipeline/stop", addr))
-                    .json(&bubbaloop::pipeline::PipelineStopRequest {
+                    .json(&bubbaloop::api::handles::PipelineStopRequest {
                         pipeline_id: pipeline_stop_command.id,
                     })
                     .send()

--- a/src/cu29/app.rs
+++ b/src/cu29/app.rs
@@ -1,9 +1,10 @@
 use cu29::prelude::*;
 use cu29_helpers::basic_copper_setup;
 use std::sync::{atomic::AtomicBool, Arc};
-const SLAB_SIZE: Option<usize> = Some(150 * 1024 * 1024);
 
-pub type PipelineResult = Result<(), Box<dyn std::error::Error + Send + Sync>>;
+use crate::pipeline::PipelineResult;
+
+const SLAB_SIZE: Option<usize> = Some(150 * 1024 * 1024);
 
 // NOTE: this will use the default config file in the current directory during compilation
 // however, it will be overridden by the ron config string when the pipeline is started

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -1,37 +1,28 @@
-use ::cu29::read_configuration;
-use axum::{
-    extract::State,
-    response::{IntoResponse, Json},
-};
-use reqwest::StatusCode;
 use serde::{Deserialize, Serialize};
-use serde_json::json;
 use std::{
     collections::HashMap,
     sync::atomic::AtomicBool,
     sync::{Arc, Mutex},
 };
 
-use crate::cu29;
-
 /// Global store of all pipelines managed by the server
 #[derive(Clone)]
 pub struct PipelineStore(pub Arc<Mutex<HashMap<String, PipelineHandle>>>);
 
-type PipelineResult = Result<(), Box<dyn std::error::Error + Send + Sync>>;
+pub type PipelineResult = Result<(), Box<dyn std::error::Error + Send + Sync>>;
 
 impl PipelineStore {
     /// Register a pipeline in the store and start it
     pub fn register_pipeline(
         &mut self,
-        name: String,
+        name: &str,
         handle: std::thread::JoinHandle<PipelineResult>,
         stop_signal: Arc<AtomicBool>,
     ) {
         self.0.lock().unwrap().insert(
-            name.clone(),
+            name.into(),
             PipelineHandle {
-                id: name.clone(),
+                id: name.into(),
                 handle,
                 status: PipelineStatus::Running,
                 stop_signal,
@@ -74,34 +65,22 @@ pub enum PipelineStatus {
 pub struct PipelineHandle {
     // a unique identifier for the pipeline
     // TODO: explore using a UUID
-    id: String,
+    pub id: String,
     /// the task that the pipeline is running
     /// TODO: create a custom error type
-    handle: std::thread::JoinHandle<PipelineResult>,
+    pub handle: std::thread::JoinHandle<PipelineResult>,
     // the status of the pipeline
-    status: PipelineStatus,
+    pub status: PipelineStatus,
     // stop signal
-    stop_signal: Arc<AtomicBool>,
+    pub stop_signal: Arc<AtomicBool>,
 }
 
 #[derive(Debug, Serialize)]
-struct PipelineInfo {
+pub struct PipelineInfo {
     // the id of the pipeline
-    id: String,
+    pub id: String,
     // the status of the pipeline
-    status: PipelineStatus,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-pub struct PipelineStartRequest {
-    // the id of the pipeline to start
-    pub pipeline_id: String,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-pub struct PipelineStopRequest {
-    // the id of the pipeline to stop
-    pub pipeline_id: String,
+    pub status: PipelineStatus,
 }
 
 // initialize the pipeline store
@@ -109,130 +88,8 @@ pub fn init_pipeline_store() -> PipelineStore {
     PipelineStore(Arc::new(Mutex::new(HashMap::new())))
 }
 
-/// Start a pipeline given its id
-pub async fn start_pipeline(
-    State(store): State<PipelineStore>,
-    Json(request): Json<PipelineStartRequest>,
-) -> impl IntoResponse {
-    // TODO: create a pipeline factory so that from the REST API we can register
-    //       a new pipeline and start it
-    // NOTE: for now we only support one pipeline ["bubbaloop"]
-    const SUPPORTED_PIPELINES: [&str; 2] = ["bubbaloop", "recording"];
-    if !SUPPORTED_PIPELINES.contains(&request.pipeline_id.as_str()) {
-        log::error!(
-            "Pipeline {} not supported. Try 'bubbaloop' or 'recording' instead",
-            request.pipeline_id
-        );
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(json!({
-                "error": "Pipeline not supported. Try 'bubbaloop' instead",
-            })),
-        );
-    }
-
-    // check if the pipeline id is already in the store
-    let pipeline_id = request.pipeline_id;
-    let mut pipeline_store = store.0.lock().expect("Failed to lock pipeline store");
-
-    if pipeline_store.contains_key(&pipeline_id) {
-        log::error!("Pipeline {} already exists", pipeline_id);
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(json!({
-                "error": "Pipeline already exists",
-            })),
-        );
-    }
-
-    // the stop signal to kill the pipeline thread
-    let stop_signal = Arc::new(AtomicBool::new(false));
-
-    let handle = match pipeline_id.as_str() {
-        "bubbaloop" => dummy_bubbaloop_thread(&pipeline_id, stop_signal.clone()),
-        "recording" => cu29::app::spawn_cu29_thread(&pipeline_id, stop_signal.clone()),
-        _ => {
-            log::error!("Pipeline {} not supported", pipeline_id);
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(json!({ "error": "Pipeline not supported" })),
-            );
-        }
-    };
-
-    // add the pipeline handle to the store
-    pipeline_store.insert(
-        pipeline_id.clone(),
-        PipelineHandle {
-            id: pipeline_id.clone(),
-            handle,
-            status: PipelineStatus::Running,
-            stop_signal,
-        },
-    );
-
-    (
-        StatusCode::OK,
-        Json(json!({
-            "message": format!("Pipeline {} started", pipeline_id),
-        })),
-    )
-}
-
-// Stop a pipeline given its id
-pub async fn stop_pipeline(
-    State(store): State<PipelineStore>,
-    Json(request): Json<PipelineStopRequest>,
-) -> impl IntoResponse {
-    log::debug!("Request to stop pipeline: {}", request.pipeline_id);
-    if !store.unregister_pipeline(&request.pipeline_id) {
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(json!({
-                "error": "Pipeline not found",
-            })),
-        );
-    }
-
-    (
-        StatusCode::OK,
-        Json(json!({ "message": format!("Pipeline {} stopped", request.pipeline_id) })),
-    )
-}
-
-// List all pipelines and return their status
-pub async fn list_pipelines(State(store): State<PipelineStore>) -> impl IntoResponse {
-    let store = store.0.lock().expect("Failed to lock pipeline store");
-    let pipelines = store
-        .values()
-        .map(|pipeline| PipelineInfo {
-            id: pipeline.id.clone(),
-            status: pipeline.status.clone(),
-        })
-        .collect::<Vec<_>>();
-    Json(pipelines)
-}
-
-/// Get the current configuration pipeline
-pub async fn get_config(State(_store): State<PipelineStore>) -> impl IntoResponse {
-    let copper_config = match read_configuration("bubbaloop.ron") {
-        Ok(config) => config,
-        Err(e) => {
-            log::error!("Failed to read configuration: {}", e);
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({ "error": "Failed to read configuration" })),
-            );
-        }
-    };
-
-    let all_nodes = copper_config.get_all_nodes();
-
-    (StatusCode::OK, Json(json!(all_nodes)))
-}
-
 /// A dummy pipeline that runs indefinitely and prints a message every second
-fn dummy_bubbaloop_thread(
+pub(crate) fn dummy_bubbaloop_thread(
     pipeline_id: &str,
     stop_signal: Arc<AtomicBool>,
 ) -> std::thread::JoinHandle<PipelineResult> {


### PR DESCRIPTION
This pull request includes significant changes to the API and pipeline management system, as well as updates to the Dockerfile and build script. The most important changes include the addition of new API endpoints for managing pipelines, refactoring the existing pipeline management code, and modifying the Dockerfile and build script to improve the build process.

### API and Pipeline Management Improvements:
* [`src/api/handles.rs`](diffhunk://#diff-fce128b363ccabde0cf56b46b019b9019488f3ef514f83ea90ed431559824cfaR1-R150): Added new API endpoints for starting, stopping, listing, and getting the configuration of pipelines. These endpoints handle pipeline management through a REST API.
* [`src/api/mod.rs`](diffhunk://#diff-4715d1ca31922b72b1d5c42d64759dfa3e247bf3fb4a9066d1c4711e6f8478f5R1-R4): Added a new `server` module and re-exported the `ApiServer` to organize the API code better.
* [`src/api/server.rs`](diffhunk://#diff-c692c1df4a8133d7241bf24a2f8c1d2b56c10ff5a1b54aef72fd9ee62638ef02L29-R34): Updated the API routes to use the new `handles` module for pipeline management endpoints.

### Code Refactoring:
* [`src/pipeline.rs`](diffhunk://#diff-2a32ceca5bf06929d98d89cd109edd79331cb80c5f19325591cec44837842d26L77-R92): Refactored the pipeline management code by moving the API handlers to the new `handles` module and making the `PipelineHandle` and `PipelineInfo` structs' fields public.
* [`src/cu29/app.rs`](diffhunk://#diff-04928ad036568d8d9e204fccbf371d96dcd0907c45e407aa247af89251e296b2L4-R7): Adjusted the imports and moved the `PipelineResult` type definition to `pipeline.rs` for better code organization.

### Build Process Improvements:
* [`docker/aarch64.Dockerfile`](diffhunk://#diff-53cdd58bc95e8423ff81ccd749b46576e340ad6ce9edbefb10934d856c9a7591L4-R17): Changed the base image version and added `gdb` and `DEBIAN_FRONTEND` environment variable to improve the build process.
* [`scripts/cross_deploy.sh`](diffhunk://#diff-916bce9c950ffed1358c472eaae721e583a4c8edb0821b63aa6a12d75e5bbe37L50-R50): Added the `-v` flag to the `cross build` command to enable verbose output during the build process.