### PR TITLE
Pipeline state improvement

### DIFF
--- a/src/api/handles/inference.rs
+++ b/src/api/handles/inference.rs
@@ -1,12 +1,20 @@
 use crate::{
-    api::models::inference::{InferenceResponse, InferenceSettingsQuery},
+    api::models::inference::{
+        InferenceResponse, InferenceSettingsQuery, InferenceSettingsResponse,
+    },
     pipeline::ServerGlobalState,
 };
 use axum::{extract::State, response::IntoResponse, Json};
-use serde_json::json;
 
 pub async fn get_inference_result(State(state): State<ServerGlobalState>) -> impl IntoResponse {
     log::debug!("Request to get inference result");
+    if !state.pipeline_store.is_inference_pipeline_running() {
+        return Json(InferenceResponse::Error {
+            error: "Inference pipeline not running. Please start the inference pipeline first."
+                .to_string(),
+        });
+    }
+
     let Ok(result) = state.result_store.inference.tx.subscribe().recv().await else {
         return Json(InferenceResponse::Error {
             error: "Failed to get inference result: `just start-pipeline inference`".to_string(),
@@ -20,13 +28,18 @@ pub async fn post_inference_settings(
     Json(query): Json<InferenceSettingsQuery>,
 ) -> impl IntoResponse {
     log::debug!("Request to post inference settings: {}", query.prompt);
+    if !state.pipeline_store.is_inference_pipeline_running() {
+        return Json(InferenceSettingsResponse::Error {
+            error: "Inference pipeline not running. Please start the inference pipeline first."
+                .to_string(),
+        });
+    }
+
     let Ok(_) = state.result_store.inference_settings.tx.send(query.prompt) else {
-        return Json(json!({
-            "error": "Failed to send inference settings"
-        }));
+        return Json(InferenceSettingsResponse::Error {
+            error: "Failed to send inference settings".to_string(),
+        });
     };
 
-    Json(json!({
-        "success": true
-    }))
+    Json(InferenceSettingsResponse::Success)
 }

--- a/src/api/handles/inference.rs
+++ b/src/api/handles/inference.rs
@@ -1,13 +1,13 @@
 use crate::{
     api::models::inference::{InferenceResponse, InferenceSettingsQuery},
-    pipeline::ResultStore,
+    pipeline::ServerGlobalState,
 };
 use axum::{extract::State, response::IntoResponse, Json};
 use serde_json::json;
 
-pub async fn get_inference_result(State(store): State<ResultStore>) -> impl IntoResponse {
+pub async fn get_inference_result(State(state): State<ServerGlobalState>) -> impl IntoResponse {
     log::debug!("Request to get inference result");
-    let Ok(result) = store.inference.tx.subscribe().recv().await else {
+    let Ok(result) = state.result_store.inference.tx.subscribe().recv().await else {
         return Json(InferenceResponse::Error {
             error: "Failed to get inference result: `just start-pipeline inference`".to_string(),
         });
@@ -16,11 +16,11 @@ pub async fn get_inference_result(State(store): State<ResultStore>) -> impl Into
 }
 
 pub async fn post_inference_settings(
-    State(store): State<ResultStore>,
+    State(state): State<ServerGlobalState>,
     Json(query): Json<InferenceSettingsQuery>,
 ) -> impl IntoResponse {
     log::debug!("Request to post inference settings: {}", query.prompt);
-    let Ok(_) = store.inference_settings.tx.send(query.prompt) else {
+    let Ok(_) = state.result_store.inference_settings.tx.send(query.prompt) else {
         return Json(json!({
             "error": "Failed to send inference settings"
         }));

--- a/src/api/handles/pipeline.rs
+++ b/src/api/handles/pipeline.rs
@@ -1,7 +1,7 @@
 use crate::{
     api::models::pipeline::{PipelineStartRequest, PipelineStopRequest},
     cu29,
-    pipeline::{self, PipelineHandle, PipelineInfo, PipelineStatus, PipelineStore},
+    pipeline::{self, PipelineHandle, PipelineStatus, ServerGlobalState},
 };
 use axum::{
     extract::State,
@@ -13,7 +13,7 @@ use std::{sync::atomic::AtomicBool, sync::Arc};
 
 /// Start a pipeline given its id
 pub async fn start_pipeline(
-    State(store): State<PipelineStore>,
+    State(state): State<ServerGlobalState>,
     Json(request): Json<PipelineStartRequest>,
 ) -> impl IntoResponse {
     log::debug!("Request to start pipeline: {}", request.name);
@@ -34,7 +34,11 @@ pub async fn start_pipeline(
 
     // check if the pipeline id is already in the store
     let pipeline_name = request.name;
-    let mut pipeline_store = store.0.lock().expect("Failed to lock pipeline store");
+    let mut pipeline_store = state
+        .pipeline_store
+        .0
+        .lock()
+        .expect("Failed to lock pipeline store");
 
     if pipeline_store.contains_key(&pipeline_name) {
         log::error!("Pipeline {} already exists", pipeline_name);
@@ -85,11 +89,11 @@ pub async fn start_pipeline(
 
 // Stop a pipeline given its id
 pub async fn stop_pipeline(
-    State(store): State<PipelineStore>,
+    State(state): State<ServerGlobalState>,
     Json(request): Json<PipelineStopRequest>,
 ) -> impl IntoResponse {
     log::debug!("Request to stop pipeline: {}", request.name);
-    if !store.unregister_pipeline(&request.name) {
+    if !state.pipeline_store.unregister_pipeline(&request.name) {
         log::error!("Pipeline {} not found", request.name);
         return (
             StatusCode::BAD_REQUEST,
@@ -108,15 +112,7 @@ pub async fn stop_pipeline(
 }
 
 // List all pipelines and return their status
-pub async fn list_pipelines(State(store): State<PipelineStore>) -> impl IntoResponse {
+pub async fn list_pipelines(State(state): State<ServerGlobalState>) -> impl IntoResponse {
     log::debug!("Request to list pipelines");
-    let store = store.0.lock().expect("Failed to lock pipeline store");
-    let pipelines = store
-        .values()
-        .map(|pipeline| PipelineInfo {
-            id: pipeline.id.clone(),
-            status: pipeline.status.clone(),
-        })
-        .collect::<Vec<_>>();
-    Json(pipelines)
+    Json(state.pipeline_store.list_pipelines())
 }

--- a/src/api/handles/recording.rs
+++ b/src/api/handles/recording.rs
@@ -1,12 +1,11 @@
 use crate::{
-    api::models::recording::RecordingQuery,
-    pipeline::{PipelineStatus, ServerGlobalState},
+    api::models::recording::{RecordingQuery, RecordingResponse},
+    pipeline::ServerGlobalState,
 };
 use axum::{
     extract::State,
     response::{IntoResponse, Json},
 };
-use serde_json::json;
 
 pub async fn post_recording_command(
     State(state): State<ServerGlobalState>,
@@ -14,36 +13,25 @@ pub async fn post_recording_command(
 ) -> impl IntoResponse {
     log::debug!("Request to post recording command: {:?}", query.command);
 
-    let pipelines = state.pipeline_store.list_pipelines();
-    let recording_pipeline = pipelines
-        .iter()
-        .filter(|p| p.id == "cameras" && p.status == PipelineStatus::Running)
-        .collect::<Vec<_>>();
-
-    if recording_pipeline.is_empty() {
-        return Json(json!({
-            "success": false,
-            "error": "Cameras pipeline not started. Please start the cameras pipeline first."
-        }));
+    if !state.pipeline_store.is_cameras_pipeline_running() {
+        return Json(RecordingResponse::Error {
+            error: "Cameras pipeline not started. Please start the cameras pipeline first."
+                .to_string(),
+        });
     }
 
     log::debug!("Request to post recording command: {:?}", query.command);
 
     if let Err(e) = state.result_store.recording.request.tx.send(query.command) {
-        return Json(json!({
-            "success": false,
-            "error": format!("Failed to send command to recording: {}", e)
-        }));
+        return Json(RecordingResponse::Error {
+            error: format!("Failed to send command to recording: {}", e),
+        });
     }
 
     match state.result_store.recording.reply.rx.lock().unwrap().recv() {
-        Ok(reply) => Json(json!({
-            "success": reply.success,
-            "error": reply.error
-        })),
-        Err(e) => Json(json!({
-            "success": false,
-            "error": format!("Failed to receive reply from recording: {}", e)
-        })),
+        Ok(reply) => Json(reply),
+        Err(e) => Json(RecordingResponse::Error {
+            error: format!("Failed to receive reply from recording: {}", e),
+        }),
     }
 }

--- a/src/api/handles/recording.rs
+++ b/src/api/handles/recording.rs
@@ -1,19 +1,49 @@
-use crate::{api::models::recording::RecordingQuery, pipeline::ResultStore};
-use axum::{extract::State, response::IntoResponse, Json};
+use crate::{
+    api::models::recording::RecordingQuery,
+    pipeline::{PipelineStatus, ServerGlobalState},
+};
+use axum::{
+    extract::State,
+    response::{IntoResponse, Json},
+};
 use serde_json::json;
 
 pub async fn post_recording_command(
-    State(store): State<ResultStore>,
+    State(state): State<ServerGlobalState>,
     Json(query): Json<RecordingQuery>,
 ) -> impl IntoResponse {
     log::debug!("Request to post recording command: {:?}", query.command);
-    let Ok(_) = store.recording.tx.send(query.command) else {
-        return Json(json!({
-            "error": "Failed to send recording"
-        }));
-    };
 
-    Json(json!({
-        "success": true
-    }))
+    let pipelines = state.pipeline_store.list_pipelines();
+    let recording_pipeline = pipelines
+        .iter()
+        .filter(|p| p.id == "cameras" && p.status == PipelineStatus::Running)
+        .collect::<Vec<_>>();
+
+    if recording_pipeline.is_empty() {
+        return Json(json!({
+            "success": false,
+            "error": "Cameras pipeline not started. Please start the cameras pipeline first."
+        }));
+    }
+
+    log::debug!("Request to post recording command: {:?}", query.command);
+
+    if let Err(e) = state.result_store.recording.request.tx.send(query.command) {
+        return Json(json!({
+            "success": false,
+            "error": format!("Failed to send command to recording: {}", e)
+        }));
+    }
+
+    match state.result_store.recording.reply.rx.lock().unwrap().recv() {
+        Ok(reply) => Json(json!({
+            "success": reply.success,
+            "error": reply.error
+        })),
+        Err(e) => Json(json!({
+            "success": false,
+            "error": format!("Failed to receive reply from recording: {}", e)
+        })),
+    }
 }

--- a/src/api/handles/streaming.rs
+++ b/src/api/handles/streaming.rs
@@ -4,14 +4,21 @@ use crate::{
 };
 use axum::{
     extract::{Path, State},
-    response::IntoResponse,
-    Json,
+    response::{IntoResponse, Json},
 };
 
 pub async fn get_streaming_image(
     Path(query): Path<StreamingQuery>,
     State(state): State<ServerGlobalState>,
 ) -> impl IntoResponse {
+    log::debug!("Request to get streaming image: {}", query.channel_id);
+    if !state.pipeline_store.is_cameras_pipeline_running() {
+        return Json(StreamingResponse::Error {
+            error: "Cameras pipeline not started. Please start the cameras pipeline first."
+                .to_string(),
+        });
+    }
+
     let Ok(result) = state.result_store.images[query.channel_id as usize]
         .tx
         .subscribe()

--- a/src/api/handles/streaming.rs
+++ b/src/api/handles/streaming.rs
@@ -1,6 +1,6 @@
 use crate::{
     api::models::streaming::{StreamingQuery, StreamingResponse},
-    pipeline::ResultStore,
+    pipeline::ServerGlobalState,
 };
 use axum::{
     extract::{Path, State},
@@ -10,9 +10,9 @@ use axum::{
 
 pub async fn get_streaming_image(
     Path(query): Path<StreamingQuery>,
-    State(store): State<ResultStore>,
+    State(state): State<ServerGlobalState>,
 ) -> impl IntoResponse {
-    let Ok(result) = store.images[query.channel_id as usize]
+    let Ok(result) = state.result_store.images[query.channel_id as usize]
         .tx
         .subscribe()
         .recv()

--- a/src/api/models/inference.rs
+++ b/src/api/models/inference.rs
@@ -21,3 +21,10 @@ pub enum InferenceResponse {
     Success(InferenceResult),
     Error { error: String },
 }
+
+/// The query for the inference settings request
+#[derive(Debug, Deserialize, Serialize)]
+pub enum InferenceSettingsResponse {
+    Success,
+    Error { error: String },
+}

--- a/src/api/models/recording.rs
+++ b/src/api/models/recording.rs
@@ -12,3 +12,10 @@ pub enum RecordingCommand {
 pub struct RecordingQuery {
     pub command: RecordingCommand,
 }
+
+/// The response for the recording request
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum RecordingResponse {
+    Success,
+    Error { error: String },
+}

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -33,9 +33,9 @@ impl ApiServer {
                     get(handles::streaming::get_streaming_image),
                 ),
             )
-            .route(
+            .nest(
                 "/api/v0/recording",
-                post(handles::recording::post_recording_command),
+                Router::new().route("/command", post(handles::recording::post_recording_command)),
             )
             .nest(
                 "/api/v0/inference",
@@ -51,10 +51,9 @@ impl ApiServer {
                 Router::new()
                     .route("/start", post(handles::pipeline::start_pipeline))
                     .route("/stop", post(handles::pipeline::stop_pipeline))
-                    .route("/list", get(handles::pipeline::list_pipelines))
-                    .with_state(state.pipeline_store),
+                    .route("/list", get(handles::pipeline::list_pipelines)), //.with_state(state.pipeline_store),
             )
-            .with_state(state.result_store);
+            .with_state(state);
 
         let listener = tokio::net::TcpListener::bind(addr).await?;
         axum::serve(listener, app).await?;

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -19,7 +19,6 @@ impl ApiServer {
 
         let app = Router::new()
             .route("/", get(|| async { "Welcome to Bubbaloop!" }))
-            //.route("/api/v0/stats/whoami", get(handles::stats::whoami))
             .nest(
                 "/api/v0/stats",
                 Router::new()
@@ -51,7 +50,7 @@ impl ApiServer {
                 Router::new()
                     .route("/start", post(handles::pipeline::start_pipeline))
                     .route("/stop", post(handles::pipeline::stop_pipeline))
-                    .route("/list", get(handles::pipeline::list_pipelines)), //.with_state(state.pipeline_store),
+                    .route("/list", get(handles::pipeline::list_pipelines)),
             )
             .with_state(state);
 

--- a/src/bin/bubbaloop.rs
+++ b/src/bin/bubbaloop.rs
@@ -179,7 +179,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         Commands::Recording(recording_command) => match recording_command.mode {
             RecordingMode::Start(_) => {
                 let response = client
-                    .post(format!("http://{}/api/v0/recording", addr))
+                    .post(format!("http://{}/api/v0/recording/command", addr))
                     .json(&bubbaloop::api::models::recording::RecordingQuery {
                         command: bubbaloop::api::models::recording::RecordingCommand::Start,
                     })
@@ -191,7 +191,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
             RecordingMode::Stop(_) => {
                 let response = client
-                    .post(format!("http://{}/api/v0/recording", addr))
+                    .post(format!("http://{}/api/v0/recording/command", addr))
                     .json(&bubbaloop::api::models::recording::RecordingQuery {
                         command: bubbaloop::api::models::recording::RecordingCommand::Stop,
                     })

--- a/src/cu29/tasks/recorder.rs
+++ b/src/cu29/tasks/recorder.rs
@@ -1,7 +1,7 @@
 use crate::{
-    api::models::recording::RecordingCommand,
+    api::models::recording::{RecordingCommand, RecordingResponse},
     cu29::msgs::EncodedImage,
-    pipeline::{Reply, SERVER_GLOBAL_STATE},
+    pipeline::SERVER_GLOBAL_STATE,
 };
 use cu29::prelude::*;
 use std::path::{Path, PathBuf};
@@ -53,11 +53,9 @@ impl<'cl> CuSinkTask<'cl> for RecorderOne {
                         .recording
                         .reply
                         .tx
-                        .send(Reply {
-                            success: false,
-                            error: Some(
-                                "Could not stop recording. Recorder is not recording".to_string(),
-                            ),
+                        .send(RecordingResponse::Error {
+                            error: "Could not stop recording. Recorder is not recording"
+                                .to_string(),
                         })
                         .map_err(|e| CuError::new_with_cause("Failed to send reply", e))?;
                 }
@@ -71,10 +69,7 @@ impl<'cl> CuSinkTask<'cl> for RecorderOne {
                         .recording
                         .reply
                         .tx
-                        .send(Reply {
-                            success: true,
-                            error: None,
-                        })
+                        .send(RecordingResponse::Success)
                         .map_err(|e| CuError::new_with_cause("Failed to send reply", e))?;
                 }
             }
@@ -85,12 +80,9 @@ impl<'cl> CuSinkTask<'cl> for RecorderOne {
                         .recording
                         .reply
                         .tx
-                        .send(Reply {
-                            success: false,
-                            error: Some(
-                                "Could not start recording. Recorder is already recording"
-                                    .to_string(),
-                            ),
+                        .send(RecordingResponse::Error {
+                            error: "Could not start recording. Recorder is already recording"
+                                .to_string(),
                         })
                         .map_err(|e| CuError::new_with_cause("Failed to send reply", e))?;
                 }
@@ -104,10 +96,7 @@ impl<'cl> CuSinkTask<'cl> for RecorderOne {
                         .recording
                         .reply
                         .tx
-                        .send(Reply {
-                            success: true,
-                            error: None,
-                        })
+                        .send(RecordingResponse::Success)
                         .map_err(|e| CuError::new_with_cause("Failed to send reply", e))?;
                     return Ok(());
                 }

--- a/src/cu29/tasks/recorder.rs
+++ b/src/cu29/tasks/recorder.rs
@@ -1,6 +1,7 @@
 use crate::{
-    api::models::recording::RecordingCommand, cu29::msgs::EncodedImage,
-    pipeline::SERVER_GLOBAL_STATE,
+    api::models::recording::RecordingCommand,
+    cu29::msgs::EncodedImage,
+    pipeline::{Reply, SERVER_GLOBAL_STATE},
 };
 use cu29::prelude::*;
 use std::path::{Path, PathBuf};
@@ -38,6 +39,7 @@ impl<'cl> CuSinkTask<'cl> for RecorderOne {
         let maybe_command = SERVER_GLOBAL_STATE
             .result_store
             .recording
+            .request
             .rx
             .lock()
             .expect("Failed to lock recording")
@@ -45,17 +47,68 @@ impl<'cl> CuSinkTask<'cl> for RecorderOne {
 
         match &mut self.state {
             RecorderState::Stopped => {
+                if let Ok(RecordingCommand::Stop) = maybe_command {
+                    SERVER_GLOBAL_STATE
+                        .result_store
+                        .recording
+                        .reply
+                        .tx
+                        .send(Reply {
+                            success: false,
+                            error: Some(
+                                "Could not stop recording. Recorder is not recording".to_string(),
+                            ),
+                        })
+                        .map_err(|e| CuError::new_with_cause("Failed to send reply", e))?;
+                }
                 if let Ok(RecordingCommand::Start) = maybe_command {
                     let (rec, rec_path) = create_recording_stream(&self.path)?;
                     self.state = RecorderState::Recording(rec);
                     log::info!("Started recording to {}", rec_path.display());
+
+                    SERVER_GLOBAL_STATE
+                        .result_store
+                        .recording
+                        .reply
+                        .tx
+                        .send(Reply {
+                            success: true,
+                            error: None,
+                        })
+                        .map_err(|e| CuError::new_with_cause("Failed to send reply", e))?;
                 }
             }
             RecorderState::Recording(rec) => {
+                if let Ok(RecordingCommand::Start) = maybe_command {
+                    SERVER_GLOBAL_STATE
+                        .result_store
+                        .recording
+                        .reply
+                        .tx
+                        .send(Reply {
+                            success: false,
+                            error: Some(
+                                "Could not start recording. Recorder is already recording"
+                                    .to_string(),
+                            ),
+                        })
+                        .map_err(|e| CuError::new_with_cause("Failed to send reply", e))?;
+                }
                 if let Ok(RecordingCommand::Stop) = maybe_command {
                     rec.flush_blocking();
                     self.state = RecorderState::Stopped;
                     log::info!("Stopped recording");
+
+                    SERVER_GLOBAL_STATE
+                        .result_store
+                        .recording
+                        .reply
+                        .tx
+                        .send(Reply {
+                            success: true,
+                            error: None,
+                        })
+                        .map_err(|e| CuError::new_with_cause("Failed to send reply", e))?;
                     return Ok(());
                 }
 
@@ -93,6 +146,7 @@ impl<'cl> CuSinkTask<'cl> for RecorderTwo {
         let maybe_command = SERVER_GLOBAL_STATE
             .result_store
             .recording
+            .request
             .rx
             .lock()
             .expect("Failed to lock recording")
@@ -150,6 +204,7 @@ impl<'cl> CuSinkTask<'cl> for RecorderThree {
         let maybe_command = SERVER_GLOBAL_STATE
             .result_store
             .recording
+            .request
             .rx
             .lock()
             .expect("Failed to lock recording")
@@ -210,6 +265,7 @@ impl<'cl> CuSinkTask<'cl> for RecorderFour {
         let maybe_command = SERVER_GLOBAL_STATE
             .result_store
             .recording
+            .request
             .rx
             .lock()
             .expect("Failed to lock recording")

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -74,6 +74,28 @@ impl<T> Default for InferenceSenderReceiver<T> {
     }
 }
 
+/// A sender and receiver for a single message
+#[derive(Clone)]
+pub struct RequestReply<T1, T2> {
+    pub request: SenderReceiver<T1>,
+    pub reply: SenderReceiver<T2>,
+}
+
+impl<T1, T2> Default for RequestReply<T1, T2> {
+    fn default() -> Self {
+        Self {
+            request: SenderReceiver::new(),
+            reply: SenderReceiver::new(),
+        }
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+pub struct Reply {
+    pub success: bool,
+    pub error: Option<String>,
+}
+
 /// Global store of all results managed by the server
 #[derive(Clone)]
 pub struct ResultStore {
@@ -82,7 +104,8 @@ pub struct ResultStore {
     pub inference_settings: SenderReceiver<String>,
     // NOTE: support a fixed number of streams
     pub images: [BroadcastSender<EncodedImage>; 8],
-    pub recording: SenderReceiver<RecordingCommand>,
+    // pub recording: SenderReceiver<RecordingCommand>,
+    pub recording: RequestReply<RecordingCommand, Reply>,
 }
 
 impl Default for ResultStore {
@@ -91,7 +114,7 @@ impl Default for ResultStore {
             inference: BroadcastSender::new(),
             inference_settings: SenderReceiver::new(),
             images: std::array::from_fn(|_| BroadcastSender::new()),
-            recording: SenderReceiver::new(),
+            recording: RequestReply::default(),
         }
     }
 }
@@ -139,10 +162,22 @@ impl PipelineStore {
             })
             .unwrap_or(false)
     }
+
+    pub fn list_pipelines(&self) -> Vec<PipelineInfo> {
+        self.0
+            .lock()
+            .unwrap()
+            .values()
+            .map(|pipeline| PipelineInfo {
+                id: pipeline.id.clone(),
+                status: pipeline.status.clone(),
+            })
+            .collect()
+    }
 }
 
 /// The current status of a pipeline
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub enum PipelineStatus {
     /// The pipeline is running in the background
     Running,

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -1,5 +1,8 @@
 use crate::{
-    api::models::{inference::InferenceResult, recording::RecordingCommand},
+    api::models::{
+        inference::InferenceResult,
+        recording::{RecordingCommand, RecordingResponse},
+    },
     cu29::msgs::EncodedImage,
 };
 use once_cell::sync::Lazy;
@@ -90,12 +93,6 @@ impl<T1, T2> Default for RequestReply<T1, T2> {
     }
 }
 
-#[derive(Clone, Serialize, Deserialize)]
-pub struct Reply {
-    pub success: bool,
-    pub error: Option<String>,
-}
-
 /// Global store of all results managed by the server
 #[derive(Clone)]
 pub struct ResultStore {
@@ -105,7 +102,7 @@ pub struct ResultStore {
     // NOTE: support a fixed number of streams
     pub images: [BroadcastSender<EncodedImage>; 8],
     // pub recording: SenderReceiver<RecordingCommand>,
-    pub recording: RequestReply<RecordingCommand, Reply>,
+    pub recording: RequestReply<RecordingCommand, RecordingResponse>,
 }
 
 impl Default for ResultStore {
@@ -173,6 +170,20 @@ impl PipelineStore {
                 status: pipeline.status.clone(),
             })
             .collect()
+    }
+
+    pub fn is_cameras_pipeline_running(&self) -> bool {
+        self.0
+            .lock()
+            .unwrap()
+            .values()
+            .any(|pipeline| pipeline.id == "cameras" && pipeline.status == PipelineStatus::Running)
+    }
+
+    pub fn is_inference_pipeline_running(&self) -> bool {
+        self.0.lock().unwrap().values().any(|pipeline| {
+            pipeline.id == "inference" && pipeline.status == PipelineStatus::Running
+        })
     }
 }
 

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -101,7 +101,6 @@ pub struct ResultStore {
     pub inference_settings: SenderReceiver<String>,
     // NOTE: support a fixed number of streams
     pub images: [BroadcastSender<EncodedImage>; 8],
-    // pub recording: SenderReceiver<RecordingCommand>,
     pub recording: RequestReply<RecordingCommand, RecordingResponse>,
 }
 


### PR DESCRIPTION
This pull request introduces significant changes to enhance the server's handling of pipelines, inference, recording, and streaming functionalities. The most notable updates include the introduction of a unified `ServerGlobalState` structure, improved handling of pipeline statuses, and the addition of new response types for better error and success reporting.

### Refactoring and State Management:
* Replaced individual state objects (`ResultStore` and `PipelineStore`) with a unified `ServerGlobalState` structure across all handlers for better state management. (`src/api/handles/inference.rs`, `src/api/handles/pipeline.rs`, `src/api/handles/recording.rs`, `src/api/handles/streaming.rs`) [[1]](diffhunk://#diff-3637b1ac64088f42e86164feb7992b5d15a5acc76849ef64c54bfa2e1251bdc8L2-R18) [[2]](diffhunk://#diff-7daf1a7677d2eeabc00b4463597fb1f21215cc1df114f051780d1799684a52a7L4-R4) [[3]](diffhunk://#diff-cb3f2471b776a57c73a89406ae74ebf34c9db66c9f961284b52e26222d075d13L1-R36) [[4]](diffhunk://#diff-1b629d88ca374ea5ab702376d5904a08fe8bdadc6c9d439910e84f8bfcc650b8L3-R22)

### Enhanced Pipeline Handling:
* Added methods to `PipelineStore` to check if specific pipelines (e.g., "inference" and "cameras") are running and to list all pipelines with their statuses. (`src/pipeline.rs`)
* Updated pipeline start, stop, and list handlers to use the new `ServerGlobalState` and leverage the enhanced pipeline methods. (`src/api/handles/pipeline.rs`) [[1]](diffhunk://#diff-7daf1a7677d2eeabc00b4463597fb1f21215cc1df114f051780d1799684a52a7L37-R41) [[2]](diffhunk://#diff-7daf1a7677d2eeabc00b4463597fb1f21215cc1df114f051780d1799684a52a7L88-R96) [[3]](diffhunk://#diff-7daf1a7677d2eeabc00b4463597fb1f21215cc1df114f051780d1799684a52a7L111-R117)

### Improved Response Handling:
* Introduced new response types (`InferenceSettingsResponse`, `RecordingResponse`) to provide structured success and error messages for inference settings and recording commands. (`src/api/models/inference.rs`, `src/api/models/recording.rs`) [[1]](diffhunk://#diff-1e9f0c65ec6049f75548ba639f25097f1caca04725f4db846a64978159dde0e5R24-R30) [[2]](diffhunk://#diff-843d8630c694c51204983c6394d5e06f6a8f55d401ee8324851498b71455d0d2R15-R21)
* Updated inference, recording, and streaming handlers to use the new response types and handle pipeline status checks more gracefully. (`src/api/handles/inference.rs`, `src/api/handles/recording.rs`, `src/api/handles/streaming.rs`) [[1]](diffhunk://#diff-3637b1ac64088f42e86164feb7992b5d15a5acc76849ef64c54bfa2e1251bdc8L19-R44) [[2]](diffhunk://#diff-cb3f2471b776a57c73a89406ae74ebf34c9db66c9f961284b52e26222d075d13L1-R36) [[3]](diffhunk://#diff-1b629d88ca374ea5ab702376d5904a08fe8bdadc6c9d439910e84f8bfcc650b8L3-R22)

### Recording System Enhancements:
* Introduced a `RequestReply` structure for handling recording commands and their responses, enabling better communication between the server and recording tasks. (`src/pipeline.rs`, `src/cu29/tasks/recorder.rs`) [[1]](diffhunk://#diff-2a32ceca5bf06929d98d89cd109edd79331cb80c5f19325591cec44837842d26R80-R95) [[2]](diffhunk://#diff-173070f48c70ae3c8955bc1ea4de499cd521824d4f30b54da90d6c6f0be4327eR42-R100)
* Updated recording tasks to handle start/stop commands more robustly and send appropriate responses back to the server. (`src/cu29/tasks/recorder.rs`) [[1]](diffhunk://#diff-173070f48c70ae3c8955bc1ea4de499cd521824d4f30b54da90d6c6f0be4327eR42-R100) [[2]](diffhunk://#diff-173070f48c70ae3c8955bc1ea4de499cd521824d4f30b54da90d6c6f0be4327eR138) [[3]](diffhunk://#diff-173070f48c70ae3c8955bc1ea4de499cd521824d4f30b54da90d6c6f0be4327eR196) [[4]](diffhunk://#diff-173070f48c70ae3c8955bc1ea4de499cd521824d4f30b54da90d6c6f0be4327eR257)

### API Routing Updates:
* Refined API routes to nest recording commands under `/api/v0/recording/command` and ensure all routes share the unified `ServerGlobalState`. (`src/api/server.rs`) [[1]](diffhunk://#diff-c692c1df4a8133d7241bf24a2f8c1d2b56c10ff5a1b54aef72fd9ee62638ef02L36-R38) [[2]](diffhunk://#diff-c692c1df4a8133d7241bf24a2f8c1d2b56c10ff5a1b54aef72fd9ee62638ef02L54-R56)